### PR TITLE
Simplify explicit definition of complex torch tensors

### DIFF
--- a/src/qcd_ml/nn/lptc.py
+++ b/src/qcd_ml/nn/lptc.py
@@ -16,8 +16,7 @@ class v_LPTC(torch.nn.Module):
     def __init__(self, n_feature_in, n_feature_out, paths, U):
         super().__init__()
         self.weights = torch.nn.Parameter(
-                torch.complex(torch.randn(n_feature_in, n_feature_out, len(paths), *tuple(U.shape[1:-2]), 4, 4, dtype=torch.double)
-                              , torch.randn(n_feature_in, n_feature_out, len(paths), *tuple(U.shape[1:-2]), 4, 4, dtype=torch.double))
+                torch.randn(n_feature_in, n_feature_out, len(paths), *tuple(U.shape[1:-2]), 4, 4, dtype=torch.cdouble)
                 )
 
         self.n_feature_in = n_feature_in
@@ -52,8 +51,7 @@ class v_LPTC_NG(torch.nn.Module):
     def __init__(self, n_feature_in, n_feature_out, paths, grid_dims, internal_dof):
         super().__init__()
         self.weights = torch.nn.Parameter(
-                torch.complex(torch.randn(n_feature_in, n_feature_out, len(paths), *tuple(grid_dims), internal_dof, internal_dof, dtype=torch.double)
-                              , torch.randn(n_feature_in, n_feature_out, len(paths), *tuple(grid_dims), internal_dof, internal_dof, dtype=torch.double))
+                torch.randn(n_feature_in, n_feature_out, len(paths), *tuple(grid_dims), internal_dof, internal_dof, dtype=torch.cdouble)
                 )
 
         self.n_feature_in = n_feature_in

--- a/src/qcd_ml/nn/ptc.py
+++ b/src/qcd_ml/nn/ptc.py
@@ -16,8 +16,7 @@ class v_PTC(torch.nn.Module):
     def __init__(self, n_feature_in, n_feature_out, paths, U):
         super().__init__()
         self.weights = torch.nn.Parameter(
-                torch.complex(torch.randn(n_feature_in, n_feature_out, len(paths), 4, 4, dtype=torch.double)
-                              , torch.randn(n_feature_in, n_feature_out, len(paths), 4, 4, dtype=torch.double))
+                torch.randn(n_feature_in, n_feature_out, len(paths), 4, 4, dtype=torch.cdouble)
                 )
 
         self.n_feature_in = n_feature_in

--- a/src/qcd_ml/qcd/static.py
+++ b/src/qcd_ml/qcd/static.py
@@ -2,32 +2,20 @@
 
 import torch
 
-gamma = [torch.complex(
-             torch.tensor([[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0]], dtype=torch.double),
-             torch.tensor([[0,0,0,1]
-                           ,[0,0,1,0]
-                           ,[0,-1,0,0]
-                           ,[-1,0,0,0]], dtype=torch.double)
-             )
-         , torch.complex(
-             torch.tensor([[0,0,0,-1]
-                           ,[0,0,1,0]
-                           ,[0,1,0,0]
-                           ,[-1,0,0,0]], dtype=torch.double),
-             torch.tensor([[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0]], dtype=torch.double)
-             )
-         , torch.complex(
-             torch.tensor([[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0]], dtype=torch.double),
-             torch.tensor([[0,0,1,0]
-                           ,[0,0,0,-1]
-                           ,[-1,0,0,0]
-                           ,[0,1,0,0]], dtype=torch.double)
-             )
-         , torch.complex(
-             torch.tensor([[0,0,1,0]
-                           ,[0,0,0,1]
-                           ,[1,0,0,0]
-                           ,[0,1,0,0]], dtype=torch.double),
-             torch.tensor([[0,0,0,0],[0,0,0,0],[0,0,0,0],[0,0,0,0]], dtype=torch.double)
-             )
+gamma = [torch.tensor([[0,0,0,1j]
+                      ,[0,0,1j,0]
+                      ,[0,-1j,0,0]
+                      ,[-1j,0,0,0]], dtype=torch.cdouble)
+         , torch.tensor([[0,0,0,-1]
+                        ,[0,0,1,0]
+                        ,[0,1,0,0]
+                        ,[-1,0,0,0]], dtype=torch.cdouble)
+         , torch.tensor([[0,0,1j,0]
+                        ,[0,0,0,-1j]
+                        ,[-1j,0,0,0]
+                        ,[0,1j,0,0]], dtype=torch.cdouble)
+         , torch.tensor([[0,0,1,0]
+                        ,[0,0,0,1]
+                        ,[1,0,0,0]
+                        ,[0,1,0,0]], dtype=torch.cdouble)
          ]

--- a/src/qcd_ml/util/qcd/multigrid.py
+++ b/src/qcd_ml/util/qcd/multigrid.py
@@ -99,8 +99,7 @@ class ZPP_Multigrid:
         """
         project fine vector v to coarse grid.
         """
-        projected = torch.complex(torch.zeros(self.L_coarse + [self.n_basis], dtype=torch.double)
-                                  , torch.zeros(self.L_coarse + [self.n_basis], dtype=torch.double))
+        projected = torch.zeros(self.L_coarse + [self.n_basis], dtype=torch.cdouble)
         lx, ly, lz, lt = self.block_size
         
         for bx, by, bz, bt in itertools.product(*(range(li) for li in self.L_coarse)):
@@ -117,8 +116,7 @@ class ZPP_Multigrid:
         prolong coarse vector v to fine grid.
         """
         lx, ly, lz, lt = self.block_size
-        prolonged = torch.complex(torch.zeros(self.L_fine + list(self.ui_blocked[0][0][0][0][0].shape[4:]), dtype=torch.double)
-                                  , torch.zeros(self.L_fine + list(self.ui_blocked[0][0][0][0][0].shape[4:]), dtype=torch.double))
+        prolonged = torch.zeros(self.L_fine + list(self.ui_blocked[0][0][0][0][0].shape[4:]), dtype=torch.cdouble)
         for bx, by, bz, bt in itertools.product(*(range(li) for li in self.L_coarse)):
             for k, uk in enumerate(self.ui_blocked[bx][by][bz][bt]):
                 prolonged[bx * lx: (bx + 1)*lx


### PR DESCRIPTION
Defining complex tensors through real and imaginary part is not necessary. Using `dtype=torch.cdouble` is more straight forward, especially for random tensors.