### PR TITLE
globalized PathBuffer

### DIFF
--- a/src/qcd_ml/base/paths.py
+++ b/src/qcd_ml/base/paths.py
@@ -117,53 +117,101 @@ def slow_v_ng_reverse_evaluate_path(path, v):
 
 class PathBuffer:
     """
-    This class brings the same functionality as v_evaluate_path and
-    v_reverse_evaluate_path but pre-computes the costly gauge transport matrix
-    multiplications.
+    This class is buffer for paths using a given gauge configuration.
+    It is intended to be used as such::
+
+        pb = PathBuffer(U)
+
+        transport_1 = pb.path([(1, 2), (0, -2),  (1, -2), (0, 2)])
+        transport_2 = pb.path([(1, 2), (3, -2),  (1, -2), (3, 2)])
+
+        vec = transport_1.v_transport(vec)
+        vec = transport_2.v_transport(vec)
+
+    This has the advantage that
+    
+    - the gauge transport matrices are pre-computed
+    - the gauge transport matrices are stored once per path buffer, 
+      i.e., when a path is re-used the memory is not duplicated.
     """
-    def __init__(self, U, path):
+    def __init__(self, U):
         if isinstance(U, list):
             # required by torch.roll below.
             U = torch.stack(U)
-        self.path = path
+        self.U = U
 
-        if len(self.path) == 0:
-            # save computational cost and memory.
-            self._is_identity = True
-        else:
-            self._is_identity = False
+        self.accumulated_U = dict()
 
-            self.accumulated_U = torch.zeros_like(U[0])
-            self.accumulated_U[:,:,:,:] = torch.complex(
-                    torch.tensor([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=torch.double)
-                    , torch.zeros(3, 3, dtype=torch.double)
-                    )
+    def _check_path_descr(self, path_descr):
+        spacetime_dim = self.U.shape[0]
+        for i, (mu, nhops) in enumerate(path_descr):
+            if mu < 0 or mu > spacetime_dim:
+                raise ValueError(f"path component {i}: mu ({mu}) is out of bounds (0, {spacetime_dim}); path: {path_descr}")
+        return True
 
-            for mu, nhops in self.path:
-                if nhops < 0:
-                    direction = -1
-                    nhops *= -1
+
+    def path(self, path_descr):
+        if len(path_descr) == 0:
+            return NoopPathBufferTransporter()
+
+        self._check_path_descr(path_descr)
+        path_indicator = tuple(path_descr)
+
+        U = self.U
+        accumulated_U = torch.zeros_like(U[0])
+        accumulated_U[:,:,:,:] = torch.complex(
+                torch.tensor([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=torch.double)
+                , torch.zeros(3, 3, dtype=torch.double)
+                )
+
+        for mu, nhops in path_descr:
+            if nhops < 0:
+                direction = -1
+                nhops *= -1
+            else:
+                direction = 1
+
+            for _ in range(nhops):
+                if direction == -1:
+                    U = torch.roll(U, 1, mu + 1) # mu + 1 because U is (mu, x, y, z, t)
+                    accumulated_U = SU3_group_compose(U[mu], accumulated_U)
                 else:
-                    direction = 1
+                    accumulated_U = SU3_group_compose(U[mu].adjoint(), accumulated_U)
+                    U = torch.roll(U, -1, mu + 1)
 
-                for _ in range(nhops):
-                    if direction == -1:
-                        U = torch.roll(U, 1, mu + 1) # mu + 1 because U is (mu, x, y, z, t)
-                        self.accumulated_U = SU3_group_compose(U[mu], self.accumulated_U)
-                    else:
-                        self.accumulated_U = SU3_group_compose(U[mu].adjoint(), self.accumulated_U)
-                        U = torch.roll(U, -1, mu + 1)
+        self.accumulated_U[path_indicator] = accumulated_U
+        return PathBufferTransporter(self, path_indicator)
+
+
+
+class NoopPathBufferTransporter:
+    __slots__ = ("path_indicator",)
+    def __init__(self):
+        self.path_indicator = tuple()
 
     @torch.compile
     def v_transport(self, v):
-        if not self._is_identity:
-            v = v_gauge_transform(self.accumulated_U, v)
-            v = v_ng_evaluate_path(self.path, v)
         return v
 
     @torch.compile
     def v_reverse_transport(self, v):
-        if not self._is_identity:
-            v = v_ng_reverse_evaluate_path(self.path, v)
-            v = v_gauge_transform(self.accumulated_U.adjoint(), v)
+        return v
+
+
+class PathBufferTransporter:
+    __slots__ = ("path_buffer", "path_indicator")
+    def __init__(self, path_buffer, path_indicator):
+        self.path_buffer = path_buffer
+        self.path_indicator = path_indicator
+
+    @torch.compile
+    def v_transport(self, v):
+        v = v_gauge_transform(self.path_buffer.accumulated_U[self.path_indicator], v)
+        v = v_ng_evaluate_path(self.path_indicator, v)
+        return v
+
+    @torch.compile
+    def v_reverse_transport(self, v):
+        v = v_ng_reverse_evaluate_path(self.path_indicator, v)
+        v = v_gauge_transform(self.path_buffer.accumulated_U[self.path_indicator].adjoint(), v)
         return v

--- a/src/qcd_ml/qcd/dirac.py
+++ b/src/qcd_ml/qcd/dirac.py
@@ -15,6 +15,7 @@ def sigmamunu(mu, nu):
 
 class dirac_wilson:
     def __init__(self, U, mass_parameter):
+        # FIXME: remove U alltogether and replace it by PathBuffer.
         self.U = U
         self.mass_parameter = mass_parameter
 
@@ -32,7 +33,8 @@ class dirac_wilson:
 
 
 class dirac_wilson_clover:
-    def __init__(self, U, mass_parameter, csw):
+    def __init__(self, U, path_buffer: PathBuffer, mass_parameter, csw):
+        # FIXME: remove U alltogether and replace it by PathBuffer.
         self.U = U
         self.mass_parameter = mass_parameter
         self.csw = csw
@@ -47,7 +49,7 @@ class dirac_wilson_clover:
                 , Hp(mu, Hp(nu, Hm(mu, Hm(nu, []))))
                 ] for nu in range(4)] for mu in range(4)]
 
-        self.plaquette_path_buffers = [[[PathBuffer(U, pi) for pi in pnu] for pnu in pmu] for pmu in plaquette_paths]
+        self.plaquette_path_buffers = [[[path_buffer.path(pi) for pi in pnu] for pnu in pmu] for pmu in plaquette_paths]
 
     def Qmunu(self, mu, nu, v):
         paths = self.plaquette_path_buffers[mu][nu]

--- a/test/test_02_dirac.py
+++ b/test/test_02_dirac.py
@@ -1,6 +1,7 @@
 import torch 
 
 from qcd_ml.qcd.dirac import dirac_wilson, dirac_wilson_clover
+from qcd_ml.base.paths import PathBuffer
 
 
 def test_dirac_wilson_precomputed(config_1500, psi_test, psi_Dw1500_m0p5_psitest):
@@ -13,7 +14,7 @@ def test_dirac_wilson_precomputed(config_1500, psi_test, psi_Dw1500_m0p5_psitest
 
 
 def test_dirac_wilson_clover_precomputed(config_1500, psi_test, psi_Dwc1500_m0p5_psitest):
-    w = dirac_wilson_clover(config_1500, -0.5, 1)
+    w = dirac_wilson_clover(config_1500, PathBuffer(config_1500), -0.5, 1)
     expect = psi_Dwc1500_m0p5_psitest
 
     got = w(psi_test)

--- a/test/test_04_ptc.py
+++ b/test/test_04_ptc.py
@@ -5,16 +5,17 @@ import pytest
 from qcd_ml.nn.ptc import v_PTC
 from qcd_ml.nn.lptc import v_LPTC
 from qcd_ml.base.operations import v_gauge_transform, link_gauge_transform
+from qcd_ml.base.paths import PathBuffer
 
 def test_v_PTC_equivariance(config_1500, psi_test, V_1500mu0_1500mu2):
     V = V_1500mu0_1500mu2
     paths = [[]] + [[(mu, 1)] for mu in range(4)] + [[(mu, -1)] for mu in range(4)]
-    layer = v_PTC(1, 1, paths, config_1500)
+    layer = v_PTC(1, 1, paths, PathBuffer(config_1500))
 
     psibar_ngt = layer.forward(torch.stack([psi_test]))[0]
     psibar_gta = v_gauge_transform(V, psibar_ngt)
 
-    layer.gauge_transform_using_transformed(link_gauge_transform(config_1500, V))
+    layer.gauge_transform_using_transformed(PathBuffer(link_gauge_transform(config_1500, V)))
     psi_test_gt = v_gauge_transform(V, psi_test)
 
     psibar_gtb = layer.forward(torch.stack([psi_test_gt]))[0]
@@ -24,12 +25,12 @@ def test_v_PTC_equivariance(config_1500, psi_test, V_1500mu0_1500mu2):
 def test_v_LPTC_equivariance(config_1500, psi_test, V_1500mu0_1500mu2):
     V = V_1500mu0_1500mu2
     paths = [[]] + [[(mu, 1)] for mu in range(4)] + [[(mu, -1)] for mu in range(4)]
-    layer = v_LPTC(1, 1, paths, config_1500)
+    layer = v_LPTC(1, 1, paths, PathBuffer(config_1500))
 
     psibar_ngt = layer.forward(torch.stack([psi_test]))[0]
     psibar_gta = v_gauge_transform(V, psibar_ngt)
 
-    layer.gauge_transform_using_transformed(link_gauge_transform(config_1500, V))
+    layer.gauge_transform_using_transformed(PathBuffer(link_gauge_transform(config_1500, V)))
     psi_test_gt = v_gauge_transform(V, psi_test)
 
     psibar_gtb = layer.forward(torch.stack([psi_test_gt]))[0]

--- a/test/test_08_path_buffer.py
+++ b/test/test_08_path_buffer.py
@@ -13,45 +13,50 @@ def test_path_buffer_00(config_1500, psi_test):
     psi = torch.randn_like(psi_test)
     path = []
 
-    pb = PathBuffer(config_1500, path)
+    pb = PathBuffer(config_1500)
+    pt = pb.path(path)
 
-    assert torch.allclose(pb.v_transport(psi), v_evaluate_path(config_1500, path, psi))
+    assert torch.allclose(pt.v_transport(psi), v_evaluate_path(config_1500, path, psi))
 
 
 def test_path_buffer_01(config_1500, psi_test):
     psi = torch.randn_like(psi_test)
     path = [(0,1)]
 
-    pb = PathBuffer(config_1500, path)
+    pb = PathBuffer(config_1500)
+    pt = pb.path(path)
 
-    assert torch.allclose(pb.v_transport(psi), v_evaluate_path(config_1500, path, psi))
+    assert torch.allclose(pt.v_transport(psi), v_evaluate_path(config_1500, path, psi))
 
 
 def test_path_buffer_02(config_1500, psi_test):
     psi = torch.randn_like(psi_test)
     path = [(0,-1)]
 
-    pb = PathBuffer(config_1500, path)
+    pb = PathBuffer(config_1500)
+    pt = pb.path(path)
 
-    assert torch.allclose(pb.v_transport(psi), v_evaluate_path(config_1500, path, psi))
+    assert torch.allclose(pt.v_transport(psi), v_evaluate_path(config_1500, path, psi))
 
 
 def test_path_buffer_03(config_1500, psi_test):
     psi = torch.randn_like(psi_test)
     path = [(0,1), (1,-2), (3,3), (2,-5)]
 
-    pb = PathBuffer(config_1500, path)
+    pb = PathBuffer(config_1500)
+    pt = pb.path(path)
 
-    assert torch.allclose(pb.v_transport(psi), v_evaluate_path(config_1500, path, psi))
+    assert torch.allclose(pt.v_transport(psi), v_evaluate_path(config_1500, path, psi))
 
 
 def test_path_buffer_reverse(config_1500, psi_test):
     psi = torch.randn_like(psi_test)
     path = [(0,1), (1,-2), (3,3), (2,-5)]
 
-    pb = PathBuffer(config_1500, path)
+    pb = PathBuffer(config_1500)
+    pt = pb.path(path)
 
-    assert torch.allclose(pb.v_reverse_transport(psi), v_reverse_evaluate_path(config_1500, path, psi))
+    assert torch.allclose(pt.v_reverse_transport(psi), v_reverse_evaluate_path(config_1500, path, psi))
 
 
 def test_path_buffer_equivariance(config_1500, psi_test, V_1500mu0_1500mu2):
@@ -59,14 +64,15 @@ def test_path_buffer_equivariance(config_1500, psi_test, V_1500mu0_1500mu2):
     V = V_1500mu0_1500mu2
 
     path = [(0,1), (2, -2), (3,1)]
-    pb = PathBuffer(config_1500, path)
+    pb = PathBuffer(config_1500)
+    pt = pb.path(path)
     
-    psibar_ngt = pb.v_transport(psi_test)
+    psibar_ngt = pt.v_transport(psi_test)
     psibar_gta = v_gauge_transform(V, psibar_ngt)
 
     U = link_gauge_transform(config_1500, V)
     psi_test_gt = v_gauge_transform(V, psi_test)
-    pb_trans = PathBuffer(U, path)
-    psibar_gtb = pb_trans.v_transport(psi_test_gt)
+    pb_trans = PathBuffer(U)
+    psibar_gtb = pb_trans.path(path).v_transport(psi_test_gt)
     
     assert torch.allclose(psibar_gtb, psibar_gta)

--- a/test/test_bench_02_path_buffer.py
+++ b/test/test_bench_02_path_buffer.py
@@ -12,7 +12,7 @@ def test_path_buffer_00(benchmark, config_1500, psi_test):
     psi = torch.randn_like(psi_test)
     path = []
 
-    pb = PathBuffer(config_1500, path)
+    pb = PathBuffer(config_1500).path(path)
     expect =  v_evaluate_path(config_1500, path, psi)
     got = benchmark(pb.v_transport, psi)
 
@@ -24,7 +24,7 @@ def test_path_buffer_01(benchmark, config_1500, psi_test):
     psi = torch.randn_like(psi_test)
     path = [(0,1)]
 
-    pb = PathBuffer(config_1500, path)
+    pb = PathBuffer(config_1500).path(path)
     expect =  v_evaluate_path(config_1500, path, psi)
     got = benchmark(pb.v_transport, psi)
 
@@ -36,7 +36,7 @@ def test_path_buffer_02(benchmark, config_1500, psi_test):
     psi = torch.randn_like(psi_test)
     path = [(0,1), (1,-1)]
 
-    pb = PathBuffer(config_1500, path)
+    pb = PathBuffer(config_1500).path(path)
     expect =  v_evaluate_path(config_1500, path, psi)
     got = benchmark(pb.v_transport, psi)
 
@@ -47,7 +47,7 @@ def test_path_buffer_03(benchmark, config_1500, psi_test):
     psi = torch.randn_like(psi_test)
     path = [(0,1), (1,-1), (3, 3)]
 
-    pb = PathBuffer(config_1500, path)
+    pb = PathBuffer(config_1500).path(path)
     expect =  v_evaluate_path(config_1500, path, psi)
     got = benchmark(pb.v_transport, psi)
 
@@ -59,7 +59,7 @@ def test_path_00(benchmark, config_1500, psi_test):
     psi = torch.randn_like(psi_test)
     path = []
 
-    pb = PathBuffer(config_1500, path)
+    pb = PathBuffer(config_1500).path(path)
     got =  benchmark(v_evaluate_path, config_1500, path, psi)
     expect = pb.v_transport(psi)
 
@@ -71,7 +71,7 @@ def test_path_01(benchmark, config_1500, psi_test):
     psi = torch.randn_like(psi_test)
     path = [(0,1)]
 
-    pb = PathBuffer(config_1500, path)
+    pb = PathBuffer(config_1500).path(path)
     got =  benchmark(v_evaluate_path, config_1500, path, psi)
     expect = pb.v_transport(psi)
 
@@ -83,7 +83,7 @@ def test_path_02(benchmark, config_1500, psi_test):
     psi = torch.randn_like(psi_test)
     path = [(0,1), (1,-1)]
 
-    pb = PathBuffer(config_1500, path)
+    pb = PathBuffer(config_1500).path(path)
     got =  benchmark(v_evaluate_path, config_1500, path, psi)
     expect = pb.v_transport(psi)
 
@@ -95,7 +95,7 @@ def test_path_03(benchmark, config_1500, psi_test):
     psi = torch.randn_like(psi_test)
     path = [(0,1), (1,-1), (3, 3)]
 
-    pb = PathBuffer(config_1500, path)
+    pb = PathBuffer(config_1500).path(path)
     got =  benchmark(v_evaluate_path, config_1500, path, psi)
     expect = pb.v_transport(psi)
 


### PR DESCRIPTION
Globalizes the `PathBuffer`.

This bring a (possibly significant) decrease of memory requirement because the gauge transporters are not stored individually per path.

Instead, a `PathBuffer` is a "global" buffer instance (ideally one per gauge field) and stores the gauge transporters.
The `PathBuffer` object is replaced by a `PathBufferTransporter` which is obtained from a `PathBuffer` using

```python
pb = PathBuffer(U)

pt = pb.path([(0,1), (2,-1)])

pt.v_transport(vec)
```

Currently, this change has the same performance as the "local" `PathBuffer` for paths of at least length 2, or the path with length 0.
For paths of length 1, the performance is slightly worse (why?) and `v_evaluate_path` is faster than both PathBuffer implementations. 

It may be possible to solve this by implementing not just length-0 paths explicitly but also length-1 paths.