### PR TITLE
Minor fixes in qcd/gauge

### DIFF
--- a/src/qcd_ml/qcd/gauge/__init__.py
+++ b/src/qcd_ml/qcd/gauge/__init__.py
@@ -1,1 +1,2 @@
+import qcd_ml.qcd.gauge.observables
 import qcd_ml.qcd.gauge.smear

--- a/src/qcd_ml/qcd/gauge/smear.py
+++ b/src/qcd_ml/qcd/gauge/smear.py
@@ -68,8 +68,6 @@ class stout:
             self.rho[mu, mu] = 0
 
     def __call__(self, U):
-        if isinstance(U, list):
-            U = torch.stack(U)
 
         Hp = lambda mu, lst: lst + [(mu, 1)]
         Hm = lambda mu, lst: lst + [(mu, -1)]


### PR DESCRIPTION
This PR is just to fix two minor issues currently present in `qcd/gauge`:

- `qcd_ml.qcd.gauge.observables` was not automatically imported
- `stout.__call__` does not handle gauge fields given as a list of fields anymore. `compiled_stout` can not deal with such fields anyways, so there is no reason for `stout` to do so.

