### PR TITLE
added C_Convolution

### DIFF
--- a/src/qcd_ml/meson.build
+++ b/src/qcd_ml/meson.build
@@ -67,3 +67,9 @@ python.install_sources(
   pure: true,
   subdir: 'qcd_ml/nn/matrix_layers'
 )
+
+python.install_sources(
+  'nn/non_gauge/__init__.py', 'nn/non_gauge/convolution.py',
+  pure: true,
+  subdir: 'qcd_ml/nn/non_gauge'
+)

--- a/src/qcd_ml/nn/__init__.py
+++ b/src/qcd_ml/nn/__init__.py
@@ -12,3 +12,4 @@ import qcd_ml.nn.lptc
 import qcd_ml.nn.pt
 import qcd_ml.nn.pt_pool
 import qcd_ml.nn.matrix_layers
+import qcd_ml.nn.non_gauge

--- a/src/qcd_ml/nn/non_gauge/__init__.py
+++ b/src/qcd_ml/nn/non_gauge/__init__.py
@@ -1,0 +1,12 @@
+r"""
+qcd_ml.nn.non_gauge
+=======================
+
+Non gauge equivariant layers.
+
+Provides the following layers:
+
+- ``C_Convolution``
+"""
+
+from .convolution import C_Convolution

--- a/src/qcd_ml/nn/non_gauge/convolution.py
+++ b/src/qcd_ml/nn/non_gauge/convolution.py
@@ -27,7 +27,7 @@ class C_Convolution(torch.nn.Module):
     def __init__(self, n_input, n_output, kernel_size, bias=True, nd=4):
         super(C_Convolution, self).__init__()
 
-        # number lattice dimensions
+        # number of lattice dimensions
         self.nd = nd
 
         # number of channels
@@ -111,13 +111,19 @@ class C_Convolution(torch.nn.Module):
         Padding size to preserve lattice size.
         """
         padding = []
-        for k in reversed(self.kernel_size):
-            if k % 2 == 0:
+        for ks in reversed(self.kernel_size):
+            if ks % 2 == 0:
                 # even kernel
-                padding.append((k - 1) // 2)
-                padding.append(k // 2)
+                padding.append((ks - 1) // 2)
+                padding.append(ks // 2)
             else:
                 # odd kernel
-                padding.append(k // 2)
-                padding.append(k // 2)
+                padding.append(ks // 2)
+                padding.append(ks // 2)
         return padding
+
+    def extra_repr(self):
+        return (
+            f"{self.n_input}, {self.n_output}, kernel_size={self.kernel_size}"
+            f", bias={self.biases is not None}"
+        )

--- a/src/qcd_ml/nn/non_gauge/convolution.py
+++ b/src/qcd_ml/nn/non_gauge/convolution.py
@@ -5,7 +5,6 @@ Non gauge equivariant convolutions.
 """
 
 import torch
-from ...base.paths import PathBuffer
 
 
 class C_Convolution(torch.nn.Module):

--- a/src/qcd_ml/nn/non_gauge/convolution.py
+++ b/src/qcd_ml/nn/non_gauge/convolution.py
@@ -1,0 +1,123 @@
+r"""
+------------
+
+Non gauge equivariant convolutions.
+"""
+
+import torch
+from ...base.paths import PathBuffer
+
+
+class C_Convolution(torch.nn.Module):
+    """
+        This class provides a :attr:`nd`-dimensional convolutional layer with circular padding.
+        Originally described for 2D convolutions in the supplemental material of https://link.aps.org/doi/10.1103/PhysRevLett.128.032003.
+
+        The convolution is defined as
+
+        .. math::
+            U_i(x) \rightarrow b_i + \sum_j \omega_{ij} \star U_j(x)
+
+        where :math:`\star` is the :attr:`nd`-dimensional `cross-correlation` operator with periodic boundary conditions.
+
+        Note:
+            Padding and stride are set automatically to preserve lattice size.
+    """
+
+    def __init__(self, n_input, n_output, kernel_size, bias=True, nd=4):
+        super(C_Convolution, self).__init__()
+
+        # number lattice dimensions
+        self.nd = nd
+
+        # number of channels
+        self.n_input = n_input
+        self.n_output = n_output
+
+        # kernel size
+        self.kernel_size = torch.nn.modules.utils._ntuple(nd)(kernel_size)
+
+        # padding size
+        self.padding = self._padding()
+
+        # stride size
+        self.stride = [1] * nd
+
+        # weights
+        self.weights = torch.nn.Parameter(torch.randn(n_input
+                                                      , n_output
+                                                      , *self.kernel_size
+                                                      , dtype=torch.cdouble))
+
+        # biases
+        if bias:
+            self.biases = torch.nn.Parameter(torch.randn(n_output, dtype=torch.cdouble))
+        else:
+            self.biases = None
+
+    def forward(self, U):
+        """
+
+            .. math::
+                U_i(x) \rightarrow b_i + \sum_j \omega_{ij} \star U_j(x)
+
+        """
+        nu = U.dim()
+        assert nu > self.nd # (C, x_0, ..., x_{nd-1}, ...)
+
+        # apply padding
+        U = self._circular_pad(U)
+
+        # unfold U
+        for i, (ks, s) in enumerate(zip(self.kernel_size, self.stride)):
+            dim = i + 1
+            U = U.unfold(dim, ks, s)
+
+        # compute convolution
+        dim0 = [0] + list(range(2, self.nd + 2))
+        dim1 = [0] + list(range(nu, self.nd + nu))
+        U = torch.tensordot(self.weights, U, dims=(dim0, dim1))
+
+        # add biases
+        if self.biases is not None:
+            U += self.biases.view(-1, *[1] * (nu - 1)).expand_as(U)
+
+        return U
+
+    def _circular_pad(self, U):
+        """
+        Apply circular padding.
+        """
+        for i, ks in enumerate(self.kernel_size):
+            if ks > 1:
+                dim = i + 1
+
+                left_i0 = U.shape[dim] - self.padding[2 * i]
+                left_i1 = U.shape[dim]
+                left_index = torch.arange(left_i0, left_i1, device=U.device)
+                left_pad = U.index_select(dim, left_index)
+
+                right_i0 = 0
+                right_i1 = self.padding[2 * i + 1]
+                right_index = torch.arange(right_i0, right_i1, device=U.device)
+                right_pad = U.index_select(dim, right_index)
+
+                U = torch.cat([left_pad, U, right_pad], dim=dim)
+
+        return U
+
+    def _padding(self):
+        """
+        Padding size to preserve lattice size.
+        """
+        padding = []
+        for k in reversed(self.kernel_size):
+            if k % 2 == 0:
+                # even kernel
+                padding.append((k - 1) // 2)
+                padding.append(k // 2)
+            else:
+                # odd kernel
+                padding.append(k // 2)
+                padding.append(k // 2)
+        return padding

--- a/test/test_16_non_gauge.py
+++ b/test/test_16_non_gauge.py
@@ -1,0 +1,40 @@
+import torch
+
+from qcd_ml.nn.non_gauge import C_Convolution
+
+
+def test_C_Convolution_circular():
+    n_input = 2
+    n_output = 1
+    stride = 3
+
+    layer = C_Convolution(n_input, n_output, stride)
+    input_features = torch.randn(n_input, 8,8,8,16, 3,3, dtype=torch.cdouble)
+
+    features_out = layer.forward(input_features)
+
+    shifts = torch.randint(1, 8, [3]).tolist() + torch.randint(1, 16, [1]).tolist()
+    dims = list(range(1, 5))
+    input_features_c = torch.roll(input_features, shifts, dims)
+
+    features_out_c = layer.forward(input_features_c)
+    assert torch.allclose(features_out, torch.roll(features_out_c, [-s for s in shifts], dims))
+
+
+def test_C_Convolution_3d():
+    n_input = 2
+    n_output = 1
+    stride = 3
+
+    layer = C_Convolution(n_input, n_output, stride, nd=3)
+    input_features = torch.randn(n_input, 8,8,16, dtype=torch.cdouble)
+
+    features_out = layer.forward(input_features)
+
+    pad3d = torch.nn.CircularPad3d(layer.padding)
+    conv3d = torch.nn.Conv3d(n_input, n_output, layer.kernel_size, layer.stride)
+    conv3d.weight = torch.nn.Parameter(layer.weights.data.transpose(0, 1))
+    conv3d.bias = layer.biases
+
+    features_out_torch = conv3d.forward(pad3d(input_features))
+    assert torch.allclose(features_out, features_out_torch)


### PR DESCRIPTION
Added circular convolution layer for arbitrary input dimension.
The 2D pytorch version of this layer was used in [PhysRevLett.128.032003](https://link.aps.org/doi/10.1103/PhysRevLett.128.032003), however pytorch supports circular convolutions only for $\dim \leq 3$.
Note that the input size for this layer follows the convention of this repository, i.e., `(C, x_0, ..., x_{nd-1}, ...)`. A version, including additional batch dimension, i.e., `(B, C, x_0, ..., x_{nd-1}, ...)` , can found [here](https://github.com/gnrraphi/qcd_ml/tree/feature/ConvNd).

This pull request includes:

-  The `C_Convolution` layer,
-  test of `C_Convolution` for periodic boundary conditions in 4D,
-  test of `C_Convolution` against pytorch circular convolution in 3D.