### PR TITLE
Remove compiled_stout class

### DIFF
--- a/test/test_11_qcd_gauge.py
+++ b/test/test_11_qcd_gauge.py
@@ -4,10 +4,8 @@ from qcd_ml.qcd.gauge.smear import stout
 
 import pytest
 
-
 def test_stout_smear_static(config_1500, config_1500_smeared_stout_rho0p1):
-    alg = stout.constant_rho(0.1)
-    smearer = alg(config_1500)
+    smearer = stout.constant_rho(0.1)
 
     U_bar = smearer(config_1500)
 
@@ -16,11 +14,10 @@ def test_stout_smear_static(config_1500, config_1500_smeared_stout_rho0p1):
 
 @pytest.mark.slow
 def test_stout_smear_static10(config_1500, config_1500_smeared_stout_rho0p1_10):
-    alg = stout.constant_rho(0.1)
-    smearer = alg(config_1500)
+    smearer = stout.constant_rho(0.1)
 
     U_bar = config_1500
     for _ in range(10):
-        U_bar = alg(U_bar)(U_bar)
+        U_bar = smearer(U_bar)
 
     assert torch.allclose(U_bar, config_1500_smeared_stout_rho0p1_10)


### PR DESCRIPTION
For each smearing step, a new `compiled_stout` class currently needs to be created (see test 11). This does not add a performance benefit, but only makes the code more complex.

This PR addresses that by removing the `compiled_stout` class and changing the `__call__` function of the `stout` class to return the smeared field directly.