### PR TITLE
Bugfix and update the weight and hermitian matrices

### DIFF
--- a/src/qcd_ml/nn/matrix_layers/exponentiation.py
+++ b/src/qcd_ml/nn/matrix_layers/exponentiation.py
@@ -14,39 +14,39 @@ class LGE_Exp(torch.nn.Module):
         U_\mu(x) \rightarrow \exp\left(\sum\limits_j \beta_{\mu,i} W_{i}(x)\right) U_\mu(x)
     """
 
-    def __init__(self, n_features_in, matrix_mode='Ah'):
+    def __init__(self, n_features_in, matrix_mode='a'):
         """
 
         :param n_features_in:
         :param matrix_mode: Type of anti-hermitian matrix used in the exponent
-        Ah -> exp(anti-hermitian)
-        H -> exp(i * hermitian)
-        Ah_H -> exp(anti-hermitian + i * hermitian)
+        a -> exp(anti-hermitian)
+        h -> exp(i * hermitian)
+        ah -> exp(anti-hermitian + i * hermitian)
         """
         super(LGE_Exp, self).__init__()
         self.matrix_mode = matrix_mode
-        if matrix_mode == "Ah" or matrix_mode == "Ah_H":
+        if matrix_mode == "a" or matrix_mode == "ah":
             self.ah_weights = torch.nn.Parameter(torch.randn(4, n_features_in, dtype=torch.double))
-        if matrix_mode == "H" or matrix_mode == "Ah_H":
+        if matrix_mode == "h" or matrix_mode == "ah":
             self.h_weights = torch.nn.Parameter(torch.randn(4, n_features_in, dtype=torch.double))
-        if matrix_mode not in ["Ah", "H", "Ah_H"]:
-            raise Exception("invalid matrix_mode. The possibilities are:\n"
-                            "Ah -> exp(anti-hermitian)\n"
-                            "H -> exp(i * hermitian)\n"
-                            "Ah_H -> exp(anti-hermitian + i * hermitian)")
+        if matrix_mode not in ["a", "h", "ah"]:
+            raise ValueError("invalid matrix_mode. The possibilities are:\n"
+                            "a -> exp(anti-hermitian)\n"
+                            "h -> exp(i * hermitian)\n"
+                            "ah -> exp(anti-hermitian + i * hermitian)")
 
     def forward(self, U, W):
         transform_matrix = torch.zeros(U.shape, dtype=torch.cdouble)
         W_adj = W.adjoint()
 
-        if self.matrix_mode == "Ah" or self.matrix_mode == "Ah_H":
+        if self.matrix_mode == "a" or self.matrix_mode == "ah":
             anti_hermitian = W - W_adj
             traceless_anti_hermitian = anti_hermitian - torch.einsum("itxyzaa,bc->itxyzbc", anti_hermitian, torch.eye(3)) / 3
 
             transform_matrix += torch.matrix_exp(torch.einsum("ui,i...->u...",
                                                               1j * self.ah_weights, -1j * traceless_anti_hermitian))
 
-        if self.matrix_mode == "H" or self.matrix_mode == "Ah_H":
+        if self.matrix_mode == "h" or self.matrix_mode == "ah":
             hermitian = W + W_adj
             traceless_hermitian = hermitian - torch.einsum("itxyzaa,bc->itxyzbc", hermitian, torch.eye(3)) / 3
 

--- a/src/qcd_ml/nn/matrix_layers/exponentiation.py
+++ b/src/qcd_ml/nn/matrix_layers/exponentiation.py
@@ -11,20 +11,46 @@ class LGE_Exp(torch.nn.Module):
     gauge links, i.e.,
 
     .. math::
-        U_\mu(x) \rightarrow \exp\left(i\sum\limits_j \beta_{\mu,i} W_{i}(x)\right) U_\mu(x)
+        U_\mu(x) \rightarrow \exp\left(\sum\limits_j \beta_{\mu,i} W_{i}(x)\right) U_\mu(x)
     """
-    def __init__(self, n_features_in):
+
+    def __init__(self, n_features_in, matrix_mode='Ah'):
+        """
+
+        :param n_features_in:
+        :param matrix_mode: Type of anti-hermitian matrix used in the exponent
+        Ah -> exp(anti-hermitian)
+        H -> exp(i * hermitian)
+        Ah_H -> exp(anti-hermitian + i * hermitian)
+        """
         super(LGE_Exp, self).__init__()
-        self.weights = torch.nn.Parameter(torch.randn(4, n_features_in, dtype=torch.cdouble))
-        
+        self.matrix_mode = matrix_mode
+        if matrix_mode == "Ah" or matrix_mode == "Ah_H":
+            self.ah_weights = torch.nn.Parameter(torch.randn(4, n_features_in, dtype=torch.double))
+        if matrix_mode == "H" or matrix_mode == "Ah_H":
+            self.h_weights = torch.nn.Parameter(torch.randn(4, n_features_in, dtype=torch.double))
+        if matrix_mode not in ["Ah", "H", "Ah_H"]:
+            raise Exception("invalid matrix_mode. The possibilities are:\n"
+                            "Ah -> exp(anti-hermitian)\n"
+                            "H -> exp(i * hermitian)\n"
+                            "Ah_H -> exp(anti-hermitian + i * hermitian)")
+
     def forward(self, U, W):
-        hermitian = W.adjoint() - W
-        trace = torch.einsum("mabcdii->mabcd", hermitian)
+        transform_matrix = torch.zeros(U.shape, dtype=torch.cdouble)
+        W_adj = W.adjoint()
 
-        identity = torch.clone(hermitian)
-        identity[:,:,:,:,:] = torch.eye(3,3, dtype=torch.cdouble)
-        trace_removal = torch.einsum("mabcdij,mabcd->mabcdij", identity, trace)
-        traceless_hermitian = 1j/2 * (hermitian -  trace_removal / 3)
+        if self.matrix_mode == "Ah" or self.matrix_mode == "Ah_H":
+            anti_hermitian = W - W_adj
+            traceless_anti_hermitian = anti_hermitian - torch.einsum("itxyzaa,bc->itxyzbc", anti_hermitian, torch.eye(3)) / 3
 
-        transform_matrix = torch.matrix_exp(1j * torch.einsum("ui,i...->u...", self.weights, traceless_hermitian))
+            transform_matrix += torch.matrix_exp(torch.einsum("ui,i...->u...",
+                                                              1j * self.ah_weights, -1j * traceless_anti_hermitian))
+
+        if self.matrix_mode == "H" or self.matrix_mode == "Ah_H":
+            hermitian = W + W_adj
+            traceless_hermitian = hermitian - torch.einsum("itxyzaa,bc->itxyzbc", hermitian, torch.eye(3)) / 3
+
+            transform_matrix += torch.matrix_exp(torch.einsum("ui,i...->u...",
+                                                              1j * self.h_weights, -1j * traceless_hermitian))
+
         return torch.einsum("uabcdij,uabcdjk->uabcdik", transform_matrix, U)

--- a/test/test_13_matrix_layers.py
+++ b/test/test_13_matrix_layers.py
@@ -81,6 +81,17 @@ def test_LGE_Exp_equivariance(config_1500, V_1500mu0_1500mu2):
     assert torch.allclose(transformed_after, transformed_before)
 
 
+def test_LGE_Exp_unitary(config_1500):
+    n_input = 1
+    layer = LGE_Exp(n_input)
+    input_features = config_1500
+    input_GE = torch.stack([PathBuffer(config_1500, [(0,1), (1,1), (0,-1), (1,-1)]).gauge_transport_matrix])
+
+    features_out = layer.forward(input_features, input_GE)
+    identity_field = torch.einsum('...,ab->...ab', torch.ones(config_1500.shape[:-2]), torch.eye(3))
+    assert torch.allclose(features_out @ features_out.adjoint(), identity_field.to(torch.cdouble))
+
+
 @pytest.mark.slow
 def test_LGE_BilinearLM_autograd():
     n_input1 = 2


### PR DESCRIPTION
Now the weights are correct to ensure that the transformed gauge links are unitary.
Added matrix_mode, "Ah" is the default mode.
"Ah" the anti-hermitian part of the W field is computed, this is multiplied by real weights and used in the exponentiation
"H" the hermitian part of the W field is computed, this is multiplied by i times real weights and used in the exponentiation
"Ah_H" both the previous modes are used (with independent weights).