### PR TITLE
Small fixes

### DIFF
--- a/src/qcd_ml/nn/matrix_layers/convolution.py
+++ b/src/qcd_ml/nn/matrix_layers/convolution.py
@@ -36,7 +36,7 @@ class LGE_Convolution(torch.nn.Module):
     where
 
     .. math::
-        (H_{\mu} M)(x) = U_{\mu}(x) M(x + \mu) U_{\mu}(x+\mu)^\dagger
+        (H_{\mu} M)(x) = U_{\mu}(x) M(x + \mu) U_{\mu}(x)^\dagger
 
     Then, the convolution is defined as
 

--- a/src/qcd_ml/nn/non_gauge/convolution.py
+++ b/src/qcd_ml/nn/non_gauge/convolution.py
@@ -63,6 +63,10 @@ class C_Convolution(torch.nn.Module):
         """
         nu = U.dim()
 
+        # expected input shape (C, x_0, ..., x_{nd-1}, ...)
+        if nu <= self.nd:
+            raise ValueError(f"shape mismatch: got {nu} but expected bigger than {self.nd}")
+
         # apply padding
         U = self._circular_pad(U)
 

--- a/src/qcd_ml/nn/non_gauge/convolution.py
+++ b/src/qcd_ml/nn/non_gauge/convolution.py
@@ -62,7 +62,6 @@ class C_Convolution(torch.nn.Module):
 
         """
         nu = U.dim()
-        assert nu > self.nd # (C, x_0, ..., x_{nd-1}, ...)
 
         # apply padding
         U = self._circular_pad(U)


### PR DESCRIPTION
Fixes #34 

Removes `assert` from code. It was used to check input size, e.g., if additional batch dimension was included to input.

This request fixes also a typo in docs.