### PR TITLE
Change imports to relative

### DIFF
--- a/src/qcd_ml/__init__.py
+++ b/src/qcd_ml/__init__.py
@@ -14,7 +14,4 @@ This package provides:
 See the README for more information.
 """
 
-import qcd_ml.base
-import qcd_ml.nn
-import qcd_ml.qcd
-import qcd_ml.util
+from . import base, nn, qcd, util

--- a/src/qcd_ml/base/__init__.py
+++ b/src/qcd_ml/base/__init__.py
@@ -8,6 +8,4 @@ This module provides fundamental operations for working with QCD data:
 - Path evaluation for gauge-equivariant operations
 """
 
-import qcd_ml.base.hop
-import qcd_ml.base.operations
-import qcd_ml.base.paths
+from . import hop, operations, paths

--- a/src/qcd_ml/nn/__init__.py
+++ b/src/qcd_ml/nn/__init__.py
@@ -1,14 +1,9 @@
 """
-This module provides neural networks for lattice QCD. 
+This module provides neural networks for lattice QCD.
 The modules ``ptc`` and ``lptc`` provide parallel transport pooling and local parallel transport pooling, respectively.
-The module ``pt_pool`` provides the ``v_ProjectLayer`` class for parallel transport pooling and some utility functions for 
+The module ``pt_pool`` provides the ``v_ProjectLayer`` class for parallel transport pooling and some utility functions for
 paralell transport pooling.
 The modules ``dense`` and ``pt`` provide dense layers and parallel transport layers, which can be used to build more general gauge-equivariant neural networks.
 """
 
-import qcd_ml.nn.dense
-import qcd_ml.nn.ptc
-import qcd_ml.nn.lptc
-import qcd_ml.nn.pt
-import qcd_ml.nn.matrix_layers
-import qcd_ml.nn.non_gauge
+from . import dense, lptc, matrix_layers, non_gauge, pt, ptc

--- a/src/qcd_ml/nn/pt_pool/__init__.py
+++ b/src/qcd_ml/nn/pt_pool/__init__.py
@@ -1,5 +1,5 @@
 """
-This package provides 
+This package provides
 
 - ``v_ProjectLayer``: A parallel transport pooling projection layer.
 - ``get_paths.get_paths_*``: Functions to generate complete sets of paths for a given block size.
@@ -10,6 +10,6 @@ For a faster implementation of the pooling and unpooling, install the package ``
 For a detailed description of the parallel transport pooling, see the paper:
 https://arxiv.org/abs/2304.10438
 """
-from .pool import v_ProjectLayer
 
-import qcd_ml.nn.pt_pool.get_paths
+from . import get_paths
+from .pool import v_ProjectLayer

--- a/src/qcd_ml/qcd/__init__.py
+++ b/src/qcd_ml/qcd/__init__.py
@@ -8,6 +8,4 @@ This module provides QCD-specific operators and utilities:
 - Gauge field operations (observables, smearing)
 """
 
-import qcd_ml.qcd.dirac
-import qcd_ml.qcd.static
-import qcd_ml.qcd.gauge
+from . import dirac, gauge, static

--- a/src/qcd_ml/qcd/gauge/__init__.py
+++ b/src/qcd_ml/qcd/gauge/__init__.py
@@ -5,5 +5,4 @@ qcd_ml.qcd.gauge
 Gauge field operations.
 """
 
-import qcd_ml.qcd.gauge.observables
-import qcd_ml.qcd.gauge.smear
+from . import observables, smear

--- a/src/qcd_ml/util/__init__.py
+++ b/src/qcd_ml/util/__init__.py
@@ -9,7 +9,4 @@ This module provides utility functions for working with tensors and solving line
 - Linear algebra utilities
 """
 
-import torch
-import qcd_ml.util.qcd
-import qcd_ml.util.solver
-import qcd_ml.util.linear_algebra
+from . import linear_algebra, qcd, solver

--- a/src/qcd_ml/util/qcd/__init__.py
+++ b/src/qcd_ml/util/qcd/__init__.py
@@ -5,4 +5,4 @@ qcd_ml.util.qcd
 QCD-specific utility functions.
 """
 
-import qcd_ml.util.qcd.multigrid
+from . import multigrid


### PR DESCRIPTION
This leads to language servers being able to understand the package structure and makes e.g. autocomplete work.